### PR TITLE
Make `callFunPack` return an output value

### DIFF
--- a/source/forever/core/scripting/ScriptableState.hx
+++ b/source/forever/core/scripting/ScriptableState.hx
@@ -55,13 +55,19 @@ class ScriptableState extends FlxTransitionableState {
 			script.set(name, obj);
 	}
 
-	public function callFunPack(method:String, ?args:Array<Dynamic>):Void {
+	public function callFunPack(method:String, ?args:Array<Dynamic>):Dynamic {
 		if (scriptPack.length == 0)
 			return;
-		if (args == null)
-			args = [];
-		for (script in scriptPack)
-			script.call(method, args);
+
+		var ret:Dynamic = null;
+		
+		for (script in scriptPack) {
+			var val:Dynamic = script.call(method, args).methodVal;
+			if (val != null) // we do not need to set the value to null if the method is a void
+				ret = val;
+		}
+		
+		return ret;
 	}
 }
 


### PR DESCRIPTION
Might be useful in some cases, also is a better alternative to `CancellableEvent` (for example, you could check if the output is false instead of making a `CancellableEvent` instance each times)

This requires [this pull request](https://github.com/crowplexus/hscript-iris/pull/1) to be merged.